### PR TITLE
fix: resolve /setup route and theme toggle issues

### DIFF
--- a/www/src/layouts/BaseLayout.astro
+++ b/www/src/layouts/BaseLayout.astro
@@ -42,7 +42,6 @@ const currentPath = Astro.url.pathname;
       };
 
       const theme = getThemePreference();
-      const isDark = theme === 'dark';
 
       // Remove both classes first
       document.documentElement.classList.remove('dark', 'light');
@@ -200,6 +199,11 @@ const currentPath = Astro.url.pathname;
         document.documentElement.classList.remove('dark', 'light');
         // Add the new theme
         document.documentElement.classList.add(newTheme);
+
+        // Save to localStorage
+        if (typeof localStorage !== 'undefined') {
+          localStorage.setItem('theme', newTheme);
+        }
 
         updateThemeIcon();
       });

--- a/www/src/pages/setup.ts
+++ b/www/src/pages/setup.ts
@@ -2,9 +2,16 @@ import type { APIRoute } from 'astro';
 
 export const prerender = false;
 
-export const GET: APIRoute = async ({ params }) => {
-  // Extract the ref parameter (version tag, commit hash, or branch)
-  const ref = params.ref?.replace('@', '') || 'main';
+export const GET: APIRoute = async ({ request, url }) => {
+  // Extract version from URL path if present (e.g., /setup@v0.1.0)
+  const pathname = url.pathname;
+  let ref = 'main';
+
+  // Check if the path contains @version syntax
+  const match = pathname.match(/\/setup@(.+)/);
+  if (match && match[1]) {
+    ref = match[1];
+  }
 
   // Construct the GitHub raw URL
   const scriptUrl = `https://raw.githubusercontent.com/marcelocra/devmagic/${ref}/setup/devcontainer-setup.sh`;

--- a/www/vercel.json
+++ b/www/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/setup@:version",
+      "destination": "/setup"
+    }
+  ]
+}


### PR DESCRIPTION
- Restructured /setup route from setup/[[ref]].ts to setup.ts for proper routing
- Added vercel.json to handle @version syntax via rewrites
- Fixed theme toggle to explicitly save to localStorage on click
- Removed unused isDark variable from inline script